### PR TITLE
New subsections describing how to configure multiple providers and to avoid user-to-user VM name collision for libvirt provider with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Vagrantfile is just a ruby script; you can set up your own variable, e.g. `commo
 
 ``Vagrantfile-multi_config_example`` shows an example where virtualbox provider and libvirt provider is both set-up. 
 
+## Vagrant+libvirt environment VM name-collision
+In a shared-machine context, vagrant+libvirt setup can have an issue where the vms overwrite each other. The libvirt VM machine name defaults to just the directory name containing the Vagrantfile and suffix ``-default``. 
+vagrant-libvirt plugin has a way to set the prefix (https://github.com/vagrant-libvirt/vagrant-libvirt/issues/289) via ``libvirt.default_prefix`` variable. 
+The Vagrantfile examples in this repository is configured to use the unix UID and the containing directory as the prefix. 
 
 ## Shared Directories and moving data between the VM and the Host
     

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ If you have more than one vagrant provider you may need to specify the provider 
 Ryo found that you can add the following [line](https://github.com/glasgow-ipl/vagrant-notes/blob/master/Vagrantfile#L21) to the vagrantfile to force use of a specific driver and provider (e.g., qemu and libvert).
 ``libvirt.driver`` option should be set to ``kvm``.
 
+## Sharing config in multi-provider environment
+
+You can write Vagrantfile to target multiple providers. Whichever provider available/defaulted will be used without selecting explicitly as shown in above section. 
+
+Vagrantfile is just a ruby script; you can set up your own variable, e.g. `common_cpu=8` and use it in the respective provider configs. 
+
+``Vagrantfile-multi_config_example`` shows an example where virtualbox provider and libvirt provider is both set-up. 
+
+
 ## Shared Directories and moving data between the VM and the Host
     
 The provided sample Vagrantfile sets up a shared directory `/vagrant` at the VM and the directory containing the Vagrantfile `.` at the host.

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ The following explains my motivation for using qemu over Virtualbox.
     
 For my specific usecase, using mininet within a VM to create a network topology, I found that using Virtualbox (6.1.x) creates latency variation within the mininet nodes.
 On the other hand, qemu with libvirt has shown consistent, expected, network latency with little to no deviation within the mininet nodes.
-As my work relies on accurate network RTT samples, I chose to use quemu over Virtualbox.
+As my work relies on accurate network RTT samples, I chose to use qemu over Virtualbox.
 
 I also found that sets up the VM-Host networking differently.
 Virtualbox sets up ssh access to the host machine by port forwarding port 22 on the VM to a port on the host.
 Qemu sets up a virtual network, assigns a private IP to the VM and uses that address and port 22 for secure shell access.
-This is a small quality of life feature which makes it easier to connect multiple VMs on one host without having to deal with port colision or manually dealing with port forwarding to instruct which host port should be used for which VM.
+This is a small quality of life feature which makes it easier to connect multiple VMs on one host without having to deal with port collision or manually dealing with port forwarding to instruct which host port should be used for which VM.
 
 ### Setting up Qemu and Libvirt with Vagrant
 
@@ -65,7 +65,7 @@ An example of a provisioning script is [provided](https://github.com/glasgow-ipl
 
 If you have more than one vagrant provider you may need to specify the provider when issuing using up, e.g., ``vagrant up --provider=libvirt``.
 Ryo found that you can add the following [line](https://github.com/glasgow-ipl/vagrant-notes/blob/master/Vagrantfile#L21) to the vagrantfile to force use of a specific driver and provider (e.g., qemu and libvert).
-``libvirt.driver`` option should be set to ``kvm``.
+``libvirt.driver`` option should be set to ``kvm``, which should enable hardware acceleration instead of using full-software emulation of the VM.
 
 ## Sharing config in multi-provider environment
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ An example of a provisioning script is [provided](https://github.com/glasgow-ipl
 If you have more than one vagrant provider you may need to specify the provider when issuing using up, e.g., ``vagrant up --provider=libvirt``.
 Ryo found that you can add the following [line](https://github.com/glasgow-ipl/vagrant-notes/blob/master/Vagrantfile#L21) to the vagrantfile to force use of a specific driver and provider (e.g., qemu and libvert).
 ``libvirt.driver`` option should be set to ``kvm``, which should enable hardware acceleration instead of using full-software emulation of the VM.
+This option should be used when available as software emulation is slow.
 
 ## Sharing config in multi-provider environment
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,9 @@ Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |libvirt|
     libvirt.memory=16384
     libvirt.cpus=8
-    libvirt.driver="kvm" # set to use KVM hypervisor (hardware accelerated) 
+    libvirt.driver="kvm" # set to use KVM hypervisor (hardware accelerated)
+    dirname = __dir__.split('/')[-1] # gets the containing directory name
+    libvirt.default_prefix = "#{Etc.getpwuid.uid}-#{dirname}-" # set to use your UID as prefix of libvirt VM to avoid collision 
   end
 
   config.vm.provision "shell", privileged: true, inline: $PROVISION

--- a/Vagrantfile-multi_config_example
+++ b/Vagrantfile-multi_config_example
@@ -21,6 +21,8 @@ Vagrant.configure("2") do |config|
     libvirt.memory=common_memory
     libvirt.cpus=common_cpu
     libvirt.driver="kvm" # set to use KVM hypervisor (hardware accelerated) 
+    dirname = __dir__.split('/')[-1] # gets the containing directory name
+    libvirt.default_prefix = "#{Etc.getpwuid.uid}-#{dirname}-" # set to use your UID as prefix of libvirt VM to avoid collision
   end
 
   config.vm.provider "virtualbox" do |vb|

--- a/Vagrantfile-multi_config_example
+++ b/Vagrantfile-multi_config_example
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+$PROVISION = <<SCRIPT
+	echo "VM Setup Completed"
+SCRIPT
+
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2004"
+  
+  # Uncomment the following to enable X11 forwarding
+  #config.ssh.forward_agent = true
+  #config.ssh.forward_x11 = true
+
+  common_cpu = 8
+  common_memory = 16384
+
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memory=common_memory
+    libvirt.cpus=common_cpu
+    libvirt.driver="kvm" # set to use KVM hypervisor (hardware accelerated) 
+  end
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.cpus = common_cpu
+    # Customize the amount of memory on the VM (in MiB):
+    vb.memory = common_memory
+  end
+
+  config.vm.provision "shell", privileged: true, inline: $PROVISION
+
+end


### PR DESCRIPTION
This set of change does the following

- Describes how to configure two providers in a single Vagrantfile
- Describes the issue where libvirt-vagrant plugin just uses the directory name for VM name, causing user-to-user name collision
- A working example Vagrant file showing libvirt+virtualbox setup
- A working examples updated to use uuid+directory name for VM name prefix